### PR TITLE
[release] 0.30.0-80-ge4b8907

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 .idea
+.bara

--- a/config/test.yml
+++ b/config/test.yml
@@ -5,7 +5,7 @@ datalabName: testlab
 domain: test-datalabs.nerc.ac.uk
 kubernetesMasterHostName: datalabs-k8s-master
 
-datalabVersion: 0.31.0-91-g96dc539
+datalabVersion: 0.30.0-80-ge4b8907
 datalabVolume: testlab
 dataVolumeSize: 100Gi
 internalVolume: testlab-internal


### PR DESCRIPTION
Release to test of 0.30.0-80-ge4b8907 to test infrastructure-api for stack restarts, https://jira.ceh.ac.uk/browse/NERCDL-637