### PR TITLE
release 0.30.0-65-g77734bcd

### DIFF
--- a/config/test.yml
+++ b/config/test.yml
@@ -5,7 +5,7 @@ datalabName: testlab
 domain: test-datalabs.nerc.ac.uk
 kubernetesMasterHostName: datalabs-k8s-master
 
-datalabVersion: 0.30.0-69-gfe733d9
+datalabVersion: 0.30.0-65-g77734bcd
 datalabVolume: testlab
 dataVolumeSize: 100Gi
 internalVolume: testlab-internal


### PR DESCRIPTION
release 0.30.0-65-g77734bcd, to test choice of storage types (nfs/glusterfs)