### PR TITLE
Nercdl 635 release 0.31.0 146 g7ff0c02

### DIFF
--- a/config/test.yml
+++ b/config/test.yml
@@ -5,7 +5,7 @@ datalabName: testlab
 domain: test-datalabs.nerc.ac.uk
 kubernetesMasterHostName: datalabs-k8s-master
 
-datalabVersion: 0.31.0-143-g27a1b13
+datalabVersion: 0.31.0-146-g7ff0c02
 datalabVolume: testlab
 dataVolumeSize: 100Gi
 internalVolume: testlab-internal

--- a/datalab-k8s-manifests.code-workspace
+++ b/datalab-k8s-manifests.code-workspace
@@ -1,0 +1,10 @@
+{
+	"folders": [
+		{
+			"path": "."
+		}
+	],
+	"settings": {
+		"editor.formatOnSave": false
+	}
+}

--- a/templates/datalab/infrastructure-authorisation.template.yml
+++ b/templates/datalab/infrastructure-authorisation.template.yml
@@ -2,7 +2,7 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: infrastructure-service-account
-  namespace: { { namespace } }
+  namespace: {{ namespace }}
 ---
 apiVersion: rbac.authorization.k8s.io/v1beta1
 kind: ClusterRole
@@ -45,7 +45,7 @@ roleRef:
 subjects:
   - kind: ServiceAccount
     name: infrastructure-service-account
-    namespace: { { namespace } }
+    namespace: {{ namespace }}
 ---
 apiVersion: rbac.authorization.k8s.io/v1beta1
 kind: ClusterRole
@@ -59,11 +59,11 @@ apiVersion: rbac.authorization.k8s.io/v1beta1
 kind: RoleBinding
 metadata:
   name: infrastructure-management-health
-  namespace: { { namespace } }
+  namespace: {{ namespace }}
 subjects:
   - kind: ServiceAccount
     name: infrastructure-service-account
-    namespace: { { namespace } }
+    namespace: {{ namespace }}
 roleRef:
   kind: ClusterRole
   name: health-check-role


### PR DESCRIPTION
- Release latest version
- Create vscode workspace file that turns off 'formatOnSave'
- Fix spaces that break template, introduced by a previous 'formatOnSave'