### PR TITLE
refactor: rename variables inline with increasing portability from auth0

### DIFF
--- a/config/ceh-production.yml
+++ b/config/ceh-production.yml
@@ -15,8 +15,8 @@ maxBodySize: 500m
 
 authService: http://datalab-auth-service.prod.svc.cluster.local
 authSignin: https://datalab.datalabs.ceh.ac.uk
-auth0ClientId: y5ynz3a4GX4uNiOJMXiOgXdfOn1kF6sr
-auth0Audience: https://datalab.datalabs.ceh.ac.uk/api
+oidcProviderClientId: y5ynz3a4GX4uNiOJMXiOgXdfOn1kF6sr
+oidcProviderAudience: https://datalab.datalabs.ceh.ac.uk/api
 authorisationAudience: https://api.datalabs.ceh.ac.uk/
 authorisationIssuer: https://authorisation.datalabs.ceh.ac.uk/
 authorisationClientId: QEv6yXf59AczfzdiavrlhC9WPIvDP437

--- a/config/production.yml
+++ b/config/production.yml
@@ -15,8 +15,8 @@ maxBodySize: 500m
 
 authService: http://datalab-auth-service.prod.svc.cluster.local
 authSignin: https://datalab.datalabs.nerc.ac.uk
-auth0ClientId: pz7ZUKi-bL79M6ADP7SWGauOiivdf6Hd
-auth0Audience: https://datalab-api.datalabs.nerc.ac.uk/
+oidcProviderClientId: pz7ZUKi-bL79M6ADP7SWGauOiivdf6Hd
+oidcProviderAudience: https://datalab-api.datalabs.nerc.ac.uk/
 authorisationAudience: https://api.datalabs.nerc.ac.uk/
 authorisationIssuer: https://authorisation.datalabs.nerc.ac.uk/
 authorisationClientId: QEv6yXf59AczfzdiavrlhC9WPIvDP437

--- a/config/test.yml
+++ b/config/test.yml
@@ -15,8 +15,8 @@ maxBodySize: 500m
 
 authService: http://datalab-auth-service.test.svc.cluster.local
 authSignin: https://testlab.test-datalabs.nerc.ac.uk
-auth0ClientId: pz7ZUKi-bL79M6ADP7SWGauOiivdf6Hd
-auth0Audience: https://datalab.datalabs.nerc.ac.uk/api
+oidcProviderClientId: pz7ZUKi-bL79M6ADP7SWGauOiivdf6Hd
+oidcProviderAudience: https://datalab.datalabs.nerc.ac.uk/api
 authorisationAudience: https://api.datalabs.nerc.ac.uk/
 authorisationIssuer: https://authorisation.datalabs.nerc.ac.uk/
 authorisationClientId: QEv6yXf59AczfzdiavrlhC9WPIvDP437

--- a/templates/datalab/datalab-auth-deployment.template.yml
+++ b/templates/datalab/datalab-auth-deployment.template.yml
@@ -123,8 +123,8 @@ spec:
               value: /etc/keys/private
             - name: AUTHORISATION_PERMISSIONS
               value: /usr/src/config/permissions.yml
-            - name: AUTH_ZERO_AUDIENCE
-              value: {{ &auth0Audience }}
+            - name: OIDC_PROVIDER_AUDIENCE
+              value: {{ &oidcProviderAudience }}
             - name: AUTHORISATION_AUDIENCE
               value: {{ &authorisationAudience }}
             - name: AUTHORISATION_ISSUER

--- a/templates/datalab/oidc-configmap.template.yml
+++ b/templates/datalab/oidc-configmap.template.yml
@@ -6,7 +6,7 @@ metadata:
 data:
   config: |
     {
-      "client_id": "{{ auth0ClientId }}",
+      "client_id": "{{ oidcProviderClientId }}",
       "redirect_uri": "https://{{ datalabName }}.{{ domain }}/callback",
       "response_type": "code",
       "scope": "openid profile",
@@ -22,7 +22,7 @@ data:
           "issuer": "https://mjbr.eu.auth0.com/",
           "authorization_endpoint": "https://mjbr.eu.auth0.com/authorize",
           "userinfo_endpoint": "https://mjbr.eu.auth0.com/userinfo",
-          "end_session_endpoint": "https://mjbr.eu.auth0.com/v2/logout?returnTo=https://{{ datalabName }}.{{ domain }}/&client_id={{ auth0ClientId }}",
+          "end_session_endpoint": "https://mjbr.eu.auth0.com/v2/logout?returnTo=https://{{ datalabName }}.{{ domain }}/&client_id={{ oidcProviderClientId }}",
           "jwks_uri": "https://mjbr.eu.auth0.com/.well-known/jwks.json",
           "token_endpoint": "https://mjbr.eu.auth0.com/oauth/token"
       }


### PR DESCRIPTION
Update configuration to support the changes to the auth service to make it more portable from Auth0. Changes to the auth service can be viewed in the [linked PR](https://github.com/NERC-CEH/datalab/pull/595).