### PR TITLE
NERCDL-679 fix: common storage_config.json path

### DIFF
--- a/config/test.yml
+++ b/config/test.yml
@@ -5,7 +5,7 @@ datalabName: testlab
 domain: test-datalabs.nerc.ac.uk
 kubernetesMasterHostName: datalabs-k8s-master
 
-datalabVersion: 0.31.0-168-gf9266e1
+datalabVersion: 0.31.0-176-g0420e8b
 datalabVolume: testlab
 dataVolumeSize: 100Gi
 internalVolume: testlab-internal

--- a/templates/datalab/datalab-api-deployment.template.yml
+++ b/templates/datalab/datalab-api-deployment.template.yml
@@ -60,7 +60,7 @@ spec:
             periodSeconds: 10
           volumeMounts:
             - name: storage-config-volume
-              mountPath: /usr/src/app/workspaces/common/src/config/storage_config.json
+              mountPath: /usr/src/app/node_modules/common/src/config/storage_config.json
               subPath: storage_config.json
       volumes:
         - name: storage-config-volume

--- a/templates/datalab/infrastructure-api-deployment.template.yml
+++ b/templates/datalab/infrastructure-api-deployment.template.yml
@@ -83,6 +83,10 @@ spec:
                 secretKeyRef:
                   name: mongo-password-secret
                   key: secret
+          volumeMounts:
+            - name: storage-config-volume
+              mountPath: /usr/src/app/node_modules/common/src/config/storage_config.json
+              subPath: storage_config.json
         - name: kubectl
           image: {{ &kubectl.imageName }}:{{ kubectl.version }}
           imagePullPolicy: IfNotPresent

--- a/templates/datalab/infrastructure-api-deployment.template.yml
+++ b/templates/datalab/infrastructure-api-deployment.template.yml
@@ -65,7 +65,7 @@ spec:
             periodSeconds: 10
           volumeMounts:
             - name: storage-config-volume
-              mountPath: /usr/src/app/workspaces/common/src/config/storage_config.json
+              mountPath: /usr/src/app/node_modules/common/src/config/storage_config.json
               subPath: storage_config.json
         - name: infrastructure-watcher
           image: {{ &infrastructureApi.imageName }}:{{ datalabVersion }}


### PR DESCRIPTION
Fixes mountPath and datalab-api starts okay, but for some reason infrastructure-watcher container is failing.