### PR TITLE
chore: remove configuration environment variables no longer used by the system

### DIFF
--- a/config/ceh-production.yml
+++ b/config/ceh-production.yml
@@ -19,9 +19,7 @@ oidcProviderClientId: y5ynz3a4GX4uNiOJMXiOgXdfOn1kF6sr
 oidcProviderAudience: https://datalab.datalabs.ceh.ac.uk/api
 authorisationAudience: https://api.datalabs.ceh.ac.uk/
 authorisationIssuer: https://authorisation.datalabs.ceh.ac.uk/
-authorisationClientId: QEv6yXf59AczfzdiavrlhC9WPIvDP437
 authorisationIdentifier: urn:auth0-authz-api
-userManagementClientId: ilh0GMVsZzqjYcBPq1sEyJeI2SReF1LP
 mongoUserName: datalabs
 
 datalabAuth:

--- a/config/production.yml
+++ b/config/production.yml
@@ -19,9 +19,7 @@ oidcProviderClientId: pz7ZUKi-bL79M6ADP7SWGauOiivdf6Hd
 oidcProviderAudience: https://datalab-api.datalabs.nerc.ac.uk/
 authorisationAudience: https://api.datalabs.nerc.ac.uk/
 authorisationIssuer: https://authorisation.datalabs.nerc.ac.uk/
-authorisationClientId: QEv6yXf59AczfzdiavrlhC9WPIvDP437
 authorisationIdentifier: urn:auth0-authz-api
-userManagementClientId: ilh0GMVsZzqjYcBPq1sEyJeI2SReF1LP
 mongoUserName: datalab
 
 datalabAuth:

--- a/config/test.yml
+++ b/config/test.yml
@@ -19,9 +19,7 @@ oidcProviderClientId: pz7ZUKi-bL79M6ADP7SWGauOiivdf6Hd
 oidcProviderAudience: https://datalab.datalabs.nerc.ac.uk/api
 authorisationAudience: https://api.datalabs.nerc.ac.uk/
 authorisationIssuer: https://authorisation.datalabs.nerc.ac.uk/
-authorisationClientId: QEv6yXf59AczfzdiavrlhC9WPIvDP437
 authorisationIdentifier: urn:auth0-authz-api
-userManagementClientId: ilh0GMVsZzqjYcBPq1sEyJeI2SReF1LP
 mongoUserName: datalab
 
 datalabAuth:

--- a/templates/datalab/datalab-auth-deployment.template.yml
+++ b/templates/datalab/datalab-auth-deployment.template.yml
@@ -104,8 +104,6 @@ spec:
           ports:
             - containerPort: 9000
           env:
-            - name: AUTHORISATION_API_CLIENT_ID
-              value: {{ authorisationClientId }}
             - name: AUTHORISATION_API_IDENTIFIER
               value: {{ authorisationIdentifier }}
             - name: DATABASE_HOST
@@ -116,18 +114,6 @@ spec:
               valueFrom:
                 secretKeyRef:
                   name: mongo-password-secret
-                  key: secret
-            - name: AUTHORISATION_API_CLIENT_SECRET
-              valueFrom:
-                secretKeyRef:
-                  name: authorisation-api-client-secret
-                  key: secret
-            - name: USER_MANAGEMENT_API_CLIENT_ID
-              value: {{ userManagementClientId }}
-            - name: USER_MANAGEMENT_API_CLIENT_SECRET
-              valueFrom:
-                secretKeyRef:
-                  name: user-management-api-client-secret
                   key: secret
             - name: PUBLIC_KEY
               value: /etc/keys/public


### PR DESCRIPTION
I have removed all references to the following configuration variables. This has a sibling PR at https://github.com/NERC-CEH/datalab/pull/631.

Template name | Env var name | Additional notes
-- | -- | --
userManagementClientId | USER_MANAGEMENT_API_CLIENT_ID |  
userManagementClientSecret | USER_MANAGEMENT_API_CLIENT_SECRET | Can remove `user-management-api-client-secret` from clusters
authorisationClientId | AUTHORISATION_API_CLIENT_ID |  
authorisationClientSecret | AUTHORISATION_API_CLIENT_SECRET | Can remove `authorisation-api-client-secret` from   clusters

