### PR TITLE
Nercdl 843 add car storage configuration

### DIFF
--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -25,6 +25,13 @@ jobs:
         uses: actions/setup-node@v1
         with:
           node-version: "12"
+      - name: Install Helm
+        # Method from Helm documentation https://helm.sh/docs/intro/install/#from-script
+        run: >
+          curl -fsSL -o get_helm.sh https://raw.githubusercontent.com/helm/helm/master/scripts/get-helm-3
+          && chmod 700 get_helm.sh
+          && ./get_helm.sh
+        shell: bash
       - name: npm install
         run: npm install
         shell: bash

--- a/.github/workflows/push.yaml
+++ b/.github/workflows/push.yaml
@@ -20,6 +20,13 @@ jobs:
         uses: actions/setup-node@v1
         with:
           node-version: "12"
+      - name: Install Helm
+        # Method from Helm documentation https://helm.sh/docs/intro/install/#from-script
+        run: >
+          curl -fsSL -o get_helm.sh https://raw.githubusercontent.com/helm/helm/master/scripts/get-helm-3
+          && chmod 700 get_helm.sh
+          && ./get_helm.sh
+        shell: bash
       - name: npm install
         run: npm install
         shell: bash

--- a/helm/datalab/templates/configmaps/catalogue-configmap.template.yml
+++ b/helm/datalab/templates/configmaps/catalogue-configmap.template.yml
@@ -6,5 +6,18 @@ metadata:
 data:
   config: |
     {
-      "available": {{ .Values.catalogueAvailable }}
+      "available": {{ .Values.catalogueAvailable }},
+      {{- if .Values.catalogueAvailable }}
+      "storage": {
+        {{- with .Values.catalogueStorage }}
+        "type": "{{ .type }}",
+
+        {{- if eq .type "nfs" }}
+        "server": "{{ .server }}",
+        "rootDirectory": "{{ .rootDirectory }}"
+        {{- end }}
+
+        {{- end }}
+      }
+      {{- end }}
     }

--- a/helm/datalab/values.yaml
+++ b/helm/datalab/values.yaml
@@ -25,6 +25,10 @@ authorisationIdentifier: urn:auth0-authz-api
 mongoUserName: datalab
 
 catalogueAvailable: true
+catalogueStorage:
+  type: nfs
+  server: 192.168.1.23
+  rootDirectory: /central-asset-repository
 
 datalabAuth:
   imageName: nerc/authorisation-svc

--- a/schema/catalogue-configmap.json
+++ b/schema/catalogue-configmap.json
@@ -1,7 +1,25 @@
 {
   "type": "object",
   "properties": {
-    "available": {"type": "boolean"}
+    "available": {"type": "boolean"},
+    "storage": {
+      "oneOf": [{
+        "type": "object",
+        "properties": {
+          "type": {
+            "type": "string",
+            "enum": ["nfs"]
+          },
+          "server": {
+            "type": "string"
+          },
+          "rootDirectory": {
+            "type": "string"
+          }
+        },
+        "additionalProperties": false
+      }]
+    }
   },
   "required": ["available"],
   "additionalProperties": false

--- a/schema/catalogue-configmap.json
+++ b/schema/catalogue-configmap.json
@@ -17,7 +17,8 @@
             "type": "string"
           }
         },
-        "additionalProperties": false
+        "additionalProperties": false,
+        "required": ["type", "server", "rootDirectory"]
       }]
     }
   },


### PR DESCRIPTION
Add configuration information about backing storage for the catalogue to the catalogue config map. This currently points to the NFS server that is available in the cluster.

I have also updated the unit-tests so that they use Helm to render the configmap templates before validating them using the JSON schema. This should let us know that the actual rendered values are valid and means we don't need to handle the Helm templating language from within the unit tests. I have added a step to install helm to the CI so that the tests have access to the `helm` executable.