### PR TITLE
feat: add nginx snippet to prevent caching of configmaps

### DIFF
--- a/helm/datalab/templates/datalab-ingress.template.yml
+++ b/helm/datalab/templates/datalab-ingress.template.yml
@@ -4,6 +4,11 @@ kind: Ingress
 metadata:
   name: datalab-ingress
   namespace: {{ .Values.namespace }}
+  nginx.ingress.kubernetes.io/configuration-snippet: |
+    if ($request_uri ~* \.(json)) {
+      expires 1M;
+      add_header Cache-Control "no-store, no-cache, must-revalidate";
+    }
 spec:
   tls:
   - hosts:


### PR DESCRIPTION
Adding a directive to prevent caching for `.json` endpoints so configmaps are reloaded on the fly, directives were chosen based on some feedback from Ray

https://www.keycdn.com/support/cache-control#cache-control-no-cache