### PR TITLE
chore: protecting datalab pods by assigning to Burstable Qos class

### DIFF
--- a/helm/datalab/templates/datalab-api-deployment.template.yml
+++ b/helm/datalab/templates/datalab-api-deployment.template.yml
@@ -21,6 +21,13 @@ spec:
         - name: datalab-api
           image: {{ .Values.datalabApi.imageName }}:{{ .Chart.AppVersion }}
           imagePullPolicy: IfNotPresent
+          resources:
+            requests:
+              cpu: 50m
+              memory: 128Mi
+            limits:
+              cpu: 500m
+              memory: 512Mi
           ports:
             - containerPort: 8000
           env:

--- a/helm/datalab/templates/datalab-app-deployment.template.yml
+++ b/helm/datalab/templates/datalab-app-deployment.template.yml
@@ -21,6 +21,13 @@ spec:
         - name: datalab-app
           image: {{ .Values.datalabApp.imageName }}:{{ .Chart.AppVersion }}
           imagePullPolicy: IfNotPresent
+          resources:
+            requests:
+              cpu: 50m
+              memory: 128Mi
+            limits:
+              cpu: 500m
+              memory: 512Mi
           ports:
             - containerPort: 80
           livenessProbe:

--- a/helm/datalab/templates/datalab-auth-deployment.template.yml
+++ b/helm/datalab/templates/datalab-auth-deployment.template.yml
@@ -104,6 +104,13 @@ spec:
         - name: datalab-auth
           image: {{ .Values.datalabAuth.imageName }}:{{ .Chart.AppVersion }}
           imagePullPolicy: IfNotPresent
+          resources:
+            requests:
+              cpu: 50m
+              memory: 128Mi
+            limits:
+              cpu: 500m
+              memory: 512Mi
           ports:
             - containerPort: 9000
           env:

--- a/helm/datalab/templates/docs-deployment.template.yml
+++ b/helm/datalab/templates/docs-deployment.template.yml
@@ -21,6 +21,13 @@ spec:
         - name: docs
           image: {{ .Values.datalabDocs.imageName }}:{{ .Chart.AppVersion }}
           imagePullPolicy: IfNotPresent
+          resources:
+            requests:
+              cpu: 50m
+              memory: 128Mi
+            limits:
+              cpu: 500m
+              memory: 512Mi
           ports:
             - containerPort: 80
           livenessProbe:

--- a/helm/datalab/templates/infrastructure-api-deployment.template.yml
+++ b/helm/datalab/templates/infrastructure-api-deployment.template.yml
@@ -22,6 +22,13 @@ spec:
         - name: infrastructure-api
           image: {{ .Values.infrastructureApi.imageName }}:{{ .Chart.AppVersion }}
           imagePullPolicy: IfNotPresent
+          resources:
+            requests:
+              cpu: 50m
+              memory: 128Mi
+            limits:
+              cpu: 500m
+              memory: 512Mi
           env:
             - name: DATALAB_DOMAIN
               value: {{ .Values.domain }}

--- a/helm/datalab/templates/mongo-deployment.template.yml
+++ b/helm/datalab/templates/mongo-deployment.template.yml
@@ -18,6 +18,13 @@ spec:
         - name: mongodb
           image: {{ .Values.mongo.imageName }}:{{ .Values.mongo.version }}
           imagePullPolicy: IfNotPresent
+          resources:
+            requests:
+              cpu: 50m
+              memory: 128Mi
+            limits:
+              cpu: 500m
+              memory: 512Mi
           env:
             - name: MONGO_INITDB_ROOT_USERNAME
               value: {{ .Values.mongoUserName }}


### PR DESCRIPTION
Adding resource definitions to the datalabs deployment definitions to prevent them being evicted. I have used the figures based on usage in the DataLabs prod. For reference -  https://kubernetes.io/docs/tasks/configure-pod-container/quality-service-pod/

Currently DataLabs pod are assigned to the "Best effort QoS" class and "Best effort" pods are the first evicted if resources are running out. The first thought was to assign them to the "Guaranteed" QoS class but there is a worry we overallocate. I have gone with this approach so they are assigned to the "Burstable" QoS class...