### PR TITLE
feat: allow for turning off app armour through helm values

### DIFF
--- a/helm/datalab/templates/datalab-api-deployment.template.yml
+++ b/helm/datalab/templates/datalab-api-deployment.template.yml
@@ -14,8 +14,10 @@ spec:
       labels:
         app: datalab-api
         environment: {{ .Values.environment }}
+      {{- if .Values.useAppArmor }}
       annotations:
         container.apparmor.security.beta.kubernetes.io/datalab-api: {{ .Values.datalabApi.policy }}
+      {{- end }}
     spec:
       containers:
         - name: datalab-api

--- a/helm/datalab/templates/datalab-app-deployment.template.yml
+++ b/helm/datalab/templates/datalab-app-deployment.template.yml
@@ -14,8 +14,10 @@ spec:
       labels:
         app: datalab-app
         environment: {{ .Values.environment }}
+      {{- if .Values.useAppArmor }}
       annotations:
         container.apparmor.security.beta.kubernetes.io/datalab-app: {{ .Values.datalabApp.policy }}
+      {{- end }}
     spec:
       containers:
         - name: datalab-app

--- a/helm/datalab/templates/datalab-auth-deployment.template.yml
+++ b/helm/datalab/templates/datalab-auth-deployment.template.yml
@@ -97,8 +97,10 @@ spec:
       labels:
         app: datalab-auth
         environment: {{ .Values.environment }}
+      {{- if .Values.useAppArmor }}
       annotations:
         container.apparmor.security.beta.kubernetes.io/datalab-auth: {{ .Values.datalabAuth.policy }}
+      {{- end }}
     spec:
       containers:
         - name: datalab-auth

--- a/helm/datalab/templates/docs-deployment.template.yml
+++ b/helm/datalab/templates/docs-deployment.template.yml
@@ -14,8 +14,10 @@ spec:
       labels:
         app: docs
         environment: {{ .Values.environment }}
+      {{- if .Values.useAppArmor }}
       annotations:
         container.apparmor.security.beta.kubernetes.io/docs: {{ .Values.datalabDocs.policy }}
+      {{- end }}
     spec:
       containers:
         - name: docs

--- a/helm/datalab/templates/infrastructure-api-deployment.template.yml
+++ b/helm/datalab/templates/infrastructure-api-deployment.template.yml
@@ -14,8 +14,10 @@ spec:
       labels:
         app: infrastructure-api
         environment: {{ .Values.environment }}
+      {{- if .Values.useAppArmor }}
       annotations:
         container.apparmor.security.beta.kubernetes.io/infrastructure-api: {{ .Values.infrastructureApi.policy }}
+      {{- end }}
     spec:
       serviceAccountName: infrastructure-service-account
       containers:

--- a/helm/datalab/values.yaml
+++ b/helm/datalab/values.yaml
@@ -24,6 +24,9 @@ authorisationIssuer: https://authorisation.datalabs.nerc.ac.uk/
 authorisationIdentifier: urn:auth0-authz-api
 mongoUserName: datalab
 
+# Don't turn this off in production!
+useAppArmor: true
+
 catalogueAvailable: true
 catalogueStorage:
   type: nfs


### PR DESCRIPTION
By default, minikube can't run containers with app armour specifications assigned to them. This commit allows for the app armour specification to be left off of the installed deployments thus easily allowing helm install into minikube.