### PR TITLE
fix: remove namespace from auth service url

### DIFF
--- a/helm/datalab/templates/infrastructure-api-deployment.template.yml
+++ b/helm/datalab/templates/infrastructure-api-deployment.template.yml
@@ -41,7 +41,7 @@ spec:
             - name: AUTH_SIGNIN_URL
               value: {{ .Values.authSignin }}
             - name: AUTHORISATION_SERVICE
-              value: {{ .Values.authService }}
+              value: http://datalab-auth-service
             - name: AUTHORISATION_AUDIENCE
               value: {{ .Values.authorisationAudience }}
             - name: AUTHORISATION_ISSUER

--- a/helm/datalab/values.yaml
+++ b/helm/datalab/values.yaml
@@ -15,7 +15,6 @@ sparkMasterAddress: spark://spark-master:7077
 sharedRLibs: /data/packages/R/%p/%v
 maxBodySize: 500m
 
-authService: http://datalab-auth-service.test.svc.cluster.local
 authSignin: https://testlab.test-datalabs.nerc.ac.uk
 oidcProviderClientId: pz7ZUKi-bL79M6ADP7SWGauOiivdf6Hd
 oidcProviderAudience: https://datalab.datalabs.nerc.ac.uk/api


### PR DESCRIPTION
Currently the auth service url is given with the namespace hardcoded in it. This means you can't just update the value for namespace to have the system deploy into a different namespace. This change removes the namespace from the URL to resolve this issue (the namespace is not needed as the target service is in the same namespace).