### PR TITLE
Fix auth service url

### DIFF
--- a/helm/datalab/Chart.yaml
+++ b/helm/datalab/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.13.0
+version: 0.13.1
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/helm/datalab/templates/_custom_helpers.tpl
+++ b/helm/datalab/templates/_custom_helpers.tpl
@@ -1,0 +1,3 @@
+{{- define "datalab.auth-service-internal-url" -}}
+http://datalab-auth-service.{{.Values.namespace}}.svc.cluster.local
+{{- end }}

--- a/helm/datalab/templates/_custom_helpers.tpl
+++ b/helm/datalab/templates/_custom_helpers.tpl
@@ -1,3 +1,7 @@
+{{/*
+Create the internal URL of the auth service using the namespace datalabs is deployed into.
+Needs to be fully resolved URL so ingress can use the service if it is deployed in a different namespace.
+*/}}
 {{- define "datalab.auth-service-internal-url" -}}
 http://datalab-auth-service.{{.Values.namespace}}.svc.cluster.local
 {{- end }}

--- a/helm/datalab/templates/infrastructure-api-deployment.template.yml
+++ b/helm/datalab/templates/infrastructure-api-deployment.template.yml
@@ -41,7 +41,7 @@ spec:
             - name: AUTH_SIGNIN_URL
               value: {{ .Values.authSignin }}
             - name: AUTHORISATION_SERVICE
-              value: http://datalab-auth-service
+              value: {{ template "datalab.auth-service-internal-url" . }}
             - name: AUTHORISATION_AUDIENCE
               value: {{ .Values.authorisationAudience }}
             - name: AUTHORISATION_ISSUER


### PR DESCRIPTION
Added a custom template that can be used to create the correct full service URL for the auth-service service. It injects the deployment namespace into the URL so that the service can be used from any namespace and the system can still be easily deployed into a new namespace by changing the value of `namespace` in the helm chart values.