### PR TITLE
NERCDL-956: use latest JupyterLab image

### DIFF
--- a/helm/datalab/Chart.yaml
+++ b/helm/datalab/Chart.yaml
@@ -15,7 +15,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.14.1
+version: 0.14.2
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to

--- a/helm/datalab/templates/configmaps/image-configmap.template.yml
+++ b/helm/datalab/templates/configmaps/image-configmap.template.yml
@@ -52,7 +52,7 @@ data:
           "versions": [
             {
               "displayName": "Dask 2.30.0 support",
-              "image": "nerc/fbf2130:f200ab964cea-dask-2.30.0"
+              "image": "nerc/jupyterlab:fbf2130-dask-2.30"
             }
           ]
         },

--- a/helm/datalab/templates/configmaps/image-configmap.template.yml
+++ b/helm/datalab/templates/configmaps/image-configmap.template.yml
@@ -42,7 +42,7 @@ data:
           "versions": [
             {
               "displayName": "Dask 2.30.0 support",
-              "image": "nerc/jupyterlab:f200ab964cea-dask-2.30.0"
+              "image": "nerc/jupyterlab:fbf2130-dask-2.30"
             }
           ]
         },
@@ -52,7 +52,7 @@ data:
           "versions": [
             {
               "displayName": "Dask 2.30.0 support",
-              "image": "nerc/jupyterlab:f200ab964cea-dask-2.30.0"
+              "image": "nerc/fbf2130:f200ab964cea-dask-2.30.0"
             }
           ]
         },


### PR DESCRIPTION
The latest image adds a conda install for dask when running env-control.  Without this, a user can still achieve the same result in their conda notebook by running

conda install dask=2.30.0