### PR TITLE
Release Dask delete/snippet/proxy

### DIFF
--- a/helm/datalab/Chart.yaml
+++ b/helm/datalab/Chart.yaml
@@ -15,13 +15,13 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.22.0
+version: 0.23.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # For DataLab, this is the Docker tag for the version to be deployed.
-appVersion: 0.32.2-12-g942173ec
+appVersion: 0.32.3-18-g3a1091d5
 
 dependencies:
   - name: metadata-catalogue

--- a/helm/datalab/templates/datalab-auth-deployment.template.yml
+++ b/helm/datalab/templates/datalab-auth-deployment.template.yml
@@ -44,6 +44,7 @@ data:
             - create
             - delete
             - list
+            - open
             - edit
         - name: users
           permissions:
@@ -78,6 +79,7 @@ data:
         - name: clusters
           permissions:
             - list
+            - open
         - name: projects
           permissions:
             - read


### PR DESCRIPTION
Covers:
* NERCDL-963 (delete clusters to mongo)
* NERCDL-965 (delete clusters on k8s)
* NERCDL-966 (allow proxy access to Dask scheduler from notebook)
* NERCDL-989 (Dask snippet button)