### PR TITLE
feat: change rstudio image version

### DIFF
--- a/helm/datalab/Chart.yaml
+++ b/helm/datalab/Chart.yaml
@@ -15,13 +15,13 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.27.0
+version: 0.28.0
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # For DataLab, this is the Docker tag for the version to be deployed.
-appVersion: 0.32.4-40-g81d59ed3
+appVersion: 0.32.5-11-g0480b614
 
 dependencies:
   - name: metadata-catalogue

--- a/helm/datalab/templates/configmaps/image-configmap.template.yml
+++ b/helm/datalab/templates/configmaps/image-configmap.template.yml
@@ -106,7 +106,7 @@ data:
             {
               "default": true,
               "displayName": "4.0.4",
-              "image": "nerc/rstudio:4.0.4",
+              "image": "nerc/rstudio:4.0.4a",
               "connectImage": "nerc/zeppelin-connect:1.1.1"
             },
             {

--- a/helm/datalab/templates/infrastructure-api-deployment.template.yml
+++ b/helm/datalab/templates/infrastructure-api-deployment.template.yml
@@ -32,6 +32,8 @@ spec:
               cpu: 500m
               memory: 512Mi
           env:
+            - name: DATALAB_NAME
+              value: {{ .Values.datalabName }}
             - name: DATALAB_DOMAIN
               value: {{ .Values.domain }}
             - name: INFRASTRUCTURE_API_PORT


### PR DESCRIPTION
Update rstudio image to the one which has libxt6 installed (as part of NERCDL-1038).
Also add datalab name as environment variable to infrastructure deployment (ready for NERCDL-457, delete datalab collection from Mongo).