### PR TITLE
updated the helm chart rshiny version and with scaling permissions

### DIFF
--- a/helm/datalab/Chart.yaml
+++ b/helm/datalab/Chart.yaml
@@ -15,13 +15,13 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.34.14
+version: 0.34.17
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # For DataLab, this is the Docker tag for the version to be deployed.
-appVersion: 0.32.5-134-ga22acdb7
+appVersion: 0.32.5-189-gb0610558
 
 dependencies:
   - name: metadata-catalogue

--- a/helm/datalab/templates/configmaps/image-configmap.template.yml
+++ b/helm/datalab/templates/configmaps/image-configmap.template.yml
@@ -83,7 +83,7 @@ data:
             {
               "default": true,
               "displayName": "4.0.4",
-              "image": "nerc/rshiny:4.0.4"
+              "image": "nerc/rshiny:4.0.4a"
             },
             {
               "displayName": "4.0.1",

--- a/helm/datalab/templates/datalab-auth-deployment.template.yml
+++ b/helm/datalab/templates/datalab-auth-deployment.template.yml
@@ -35,6 +35,7 @@ data:
             - list
             - open
             - edit
+            - scale
         - name: storage
           permissions:
             - create
@@ -49,6 +50,7 @@ data:
             - list
             - open
             - edit
+            - scale
         - name: users
           permissions:
             - list


### PR DESCRIPTION
Updated the rshiny image to point to 4.0.4a as well as adding the right permissions to the auth service for scaling notebooks.