### PR TITLE
NERCDL-515: Make stacks private

### DIFF
--- a/helm/datalab/Chart.yaml
+++ b/helm/datalab/Chart.yaml
@@ -15,13 +15,13 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.34.25
+version: 0.34.32
 
 # This is the version number of the application being deployed. This version number should be
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # For DataLab, this is the Docker tag for the version to be deployed.
-appVersion: 0.33.0-105-gb2bb2ab1
+appVersion: 0.33.0-157-gcac80c9e
 
 dependencies:
   - name: metadata-catalogue

--- a/helm/datalab/templates/infrastructure-api-deployment.template.yml
+++ b/helm/datalab/templates/infrastructure-api-deployment.template.yml
@@ -40,6 +40,8 @@ spec:
               value: '8000'
             - name: KUBERNETES_NAMESPACE
               value: {{ .Values.namespace }}
+            - name: DEPLOYED_IN_CLUSTER
+              value: 'true'
             - name: AUTH_SIGNIN_URL
               value: {{ .Values.authSignin }}
             - name: AUTHORISATION_SERVICE

--- a/helm/datalab/templates/infrastructure-authorisation.template.yml
+++ b/helm/datalab/templates/infrastructure-authorisation.template.yml
@@ -15,7 +15,8 @@ rules:
         "extensions",
         "rbac.authorization.k8s.io",
         "networking.k8s.io",
-        "autoscaling"
+        "autoscaling",
+        "batch"
       ] # "" is the core API group
     resources:
       [
@@ -33,7 +34,8 @@ rules:
         "serviceaccounts",
         "rolebindings",
         "networkpolicies",
-        "horizontalpodautoscalers"
+        "horizontalpodautoscalers",
+        "jobs"
       ]
     verbs: ["get", "list", "update", "create", "patch", "delete", "watch"]
 ---


### PR DESCRIPTION
Updated manifests to handle making stacks private.
* Updated cluster role to allow for creating jobs
* Added environment variable (DEPLOYED_IN_CLUSTER) to infrastructure api